### PR TITLE
Checking for and adding universe repository and changing DNS ttl

### DIFF
--- a/etc/unbound/unbound.conf
+++ b/etc/unbound/unbound.conf
@@ -23,44 +23,44 @@ server:
     ## Steam °|-lc-host-vint:1
         local-zone: "steampowered.com." transparent
         local-zone: "client-download.steampowered.com." redirect
-        local-data: "client-download.steampowered.com. 600 IN A lc-host-steam"
+        local-data: "client-download.steampowered.com. 30 IN A lc-host-steam"
         local-zone: "content1.steampowered.com." redirect
-        local-data: "content1.steampowered.com. 600 IN A lc-host-steam"
+        local-data: "content1.steampowered.com. 30 IN A lc-host-steam"
         local-zone: "content2.steampowered.com." redirect
-        local-data: "content2.steampowered.com. 600 IN A lc-host-steam"
+        local-data: "content2.steampowered.com. 30 IN A lc-host-steam"
         local-zone: "content3.steampowered.com." redirect
-        local-data: "content3.steampowered.com. 600 IN A lc-host-steam"
+        local-data: "content3.steampowered.com. 30 IN A lc-host-steam"
         local-zone: "content4.steampowered.com." redirect
-        local-data: "content4.steampowered.com. 600 IN A lc-host-steam"
+        local-data: "content4.steampowered.com. 30 IN A lc-host-steam"
         local-zone: "content5.steampowered.com." redirect
-        local-data: "content5.steampowered.com. 600 IN A lc-host-steam"
+        local-data: "content5.steampowered.com. 30 IN A lc-host-steam"
         local-zone: "content6.steampowered.com." redirect
-        local-data: "content6.steampowered.com. 600 IN A lc-host-steam"
+        local-data: "content6.steampowered.com. 30 IN A lc-host-steam"
         local-zone: "content7.steampowered.com." redirect
-        local-data: "content7.steampowered.com. 600 IN A lc-host-steam"
+        local-data: "content7.steampowered.com. 30 IN A lc-host-steam"
         local-zone: "content8.steampowered.com." redirect
-        local-data: "content8.steampowered.com. 600 IN A lc-host-steam"
+        local-data: "content8.steampowered.com. 30 IN A lc-host-steam"
         local-zone: "cs.steampowered.com." redirect
-        local-data: "cs.steampowered.com. 600 IN A lc-host-steam"
+        local-data: "cs.steampowered.com. 30 IN A lc-host-steam"
         local-zone: "clientconfig.akamai.steamtransparent.com." redirect
-        local-data: "clientconfig.akamai.steamtransparent.com. 600 IN A lc-host-steam"
+        local-data: "clientconfig.akamai.steamtransparent.com. 30 IN A lc-host-steam"
         local-zone: "hsar.steampowered.com.edgesuite.net." redirect
-        local-data: "hsar.steampowered.com.edgesuite.net. 600 IN A lc-host-steam"
+        local-data: "hsar.steampowered.com.edgesuite.net. 30 IN A lc-host-steam"
         local-zone: "steamcontent.com." redirect
-        # local-data: "steampipe.steamcontent.com. 600 IN A lc-host-steam"
-        local-data: "steamcontent.com. 600 IN A lc-host-steam"
+        # local-data: "steampipe.steamcontent.com. 30 IN A lc-host-steam"
+        local-data: "steamcontent.com. 30 IN A lc-host-steam"
         local-zone: "edgecast.steamstatic.com." redirect        
-        local-data: "edgecast.steamstatic.com. 600 IN A lc-host-steam"
+        local-data: "edgecast.steamstatic.com. 30 IN A lc-host-steam"
         local-zone: "steampipe.akamaized.net." redirect
-        local-data: "steampipe.akamaized.net. 600 IN A lc-host-steam"
+        local-data: "steampipe.akamaized.net. 30 IN A lc-host-steam"
         local-zone: "steam.apac.qtlglb.com." redirect
-        local-data: "steam.apac.qtlglb.com. 600 IN A lc-host-steam"
+        local-data: "steam.apac.qtlglb.com. 30 IN A lc-host-steam"
         local-zone: "steam.apac.qtlglb.com.mwcloudcdn.com." redirect
-        local-data: "steam.apac.qtlglb.com.mwcloudcdn.com. 600 IN A lc-host-steam"
+        local-data: "steam.apac.qtlglb.com.mwcloudcdn.com. 30 IN A lc-host-steam"
         local-zone: "cdn1-sea1.valve.net." redirect
-        local-data: "cdn1-sea1.valve.net. 600 IN A lc-host-steam"
+        local-data: "cdn1-sea1.valve.net. 30 IN A lc-host-steam"
         local-zone: "cdn2-sea1.valve.net." redirect
-        local-data: "cdn2-sea1.valve.net. 600 IN A lc-host-steam"
+        local-data: "cdn2-sea1.valve.net. 30 IN A lc-host-steam"
 	# Refuse for Comcast CDN Issues
 	local-zone: "edge.steam-dns.top.comcast.net." refuse
         local-zone: "edge.steam-dns-2.top.comcast.net." refuse       
@@ -69,190 +69,190 @@ server:
     ## Riot Games °|-lc-host-vint:2
         local-zone: "riotgames.com." transparent
         local-zone: "l3cdn.riotgames.com." redirect
-        local-data: "l3cdn.riotgames.com. 600 IN A lc-host-riot"
+        local-data: "l3cdn.riotgames.com. 30 IN A lc-host-riot"
         local-zone: "riotgamespatcher-a.akamaihd.net." redirect
-        local-data: "riotgamespatcher-a.akamaihd.net. 600 IN A lc-host-riot"
+        local-data: "riotgamespatcher-a.akamaihd.net. 30 IN A lc-host-riot"
         local-zone: "riotgamespatcher-a.akamaihd.net.edgesuite.net." redirect
-        local-data: "riotgamespatcher-a.akamaihd.net.edgesuite.net. 600 IN A lc-host-riot"
+        local-data: "riotgamespatcher-a.akamaihd.net.edgesuite.net. 30 IN A lc-host-riot"
         local-zone: "riotgamespatcher-b.akamaihd.net." redirect
-        local-data: "riotgamespatcher-b.akamaihd.net. 600 IN A lc-host-riot"
+        local-data: "riotgamespatcher-b.akamaihd.net. 30 IN A lc-host-riot"
         local-zone: "riotgamespatcher-b.akamaihd.net.edgesuite.net." redirect
-        local-data: "riotgamespatcher-b.akamaihd.net.edgesuite.net. 600 IN A lc-host-riot"
+        local-data: "riotgamespatcher-b.akamaihd.net.edgesuite.net. 30 IN A lc-host-riot"
         local-zone: "worldwide.l3cdn.riotgames.com." redirect
-        local-data: "worldwide.l3cdn.riotgames.com. 600 IN A lc-host-riot" 
+        local-data: "worldwide.l3cdn.riotgames.com. 30 IN A lc-host-riot" 
 
     ## Blizzard °|-lc-host-vint:3
         local-zone: "edgesuite.net." transparent
         local-zone: "dist.blizzard.com." redirect
-        local-data: "dist.blizzard.com. 600 IN A lc-host-blizzard"
+        local-data: "dist.blizzard.com. 30 IN A lc-host-blizzard"
         local-zone: "llnw.blizzard.com." redirect
-        local-data: "llnw.blizzard.com. 600 IN A lc-host-blizzard"
+        local-data: "llnw.blizzard.com. 30 IN A lc-host-blizzard"
         local-zone: "level3.blizzard.com." redirect
-        local-data: "level3.blizzard.com. 600 IN A lc-host-blizzard"
+        local-data: "level3.blizzard.com. 30 IN A lc-host-blizzard"
         local-zone: "dist.blizzard.com.edgesuite.net." redirect
-        local-data: "dist.blizzard.com.edgesuite.net. 600 IN A lc-host-blizzard"
+        local-data: "dist.blizzard.com.edgesuite.net. 30 IN A lc-host-blizzard"
         local-zone: "blzddist1-a.akamaihd.net." redirect
-        local-data: "blzddist1-a.akamaihd.net. 600 IN A lc-host-blizzard"
+        local-data: "blzddist1-a.akamaihd.net. 30 IN A lc-host-blizzard"
         local-zone: "blzddist2-a.akamaihd.net." redirect
-        local-data: "blzddist2-a.akamaihd.net. 600 IN A lc-host-blizzard"
+        local-data: "blzddist2-a.akamaihd.net. 30 IN A lc-host-blizzard"
         local-zone: "blzddist1-b.akamaihd.net." redirect
-        local-data: "blzddist1-b.akamaihd.net. 600 IN A lc-host-blizzard"
+        local-data: "blzddist1-b.akamaihd.net. 30 IN A lc-host-blizzard"
         local-zone: "blzddist2-b.akamaihd.net." redirect
-        local-data: "blzddist2-b.akamaihd.net. 600 IN A lc-host-blizzard"
+        local-data: "blzddist2-b.akamaihd.net. 30 IN A lc-host-blizzard"
         local-zone: "blzddist3-a.akamaihd.net." redirect
-        local-data: "blzddist3-a.akamaihd.net. 600 IN A lc-host-blizzard"
+        local-data: "blzddist3-a.akamaihd.net. 30 IN A lc-host-blizzard"
         local-zone: "blzddist3-b.akamaihd.net." redirect
-        local-data: "blzddist3-b.akamaihd.net. 600 IN A lc-host-blizzard"
+        local-data: "blzddist3-b.akamaihd.net. 30 IN A lc-host-blizzard"
         local-zone: "blizzard.vo.llnwd.net." redirect
-        local-data: "blizzard.vo.llnwd.net. 600 IN A lc-host-blizzard"
+        local-data: "blizzard.vo.llnwd.net. 30 IN A lc-host-blizzard"
         local-zone: "edge.blizzard.top.comcast.net." redirect
-        local-data: "edge.blizzard.top.comcast.net. 600 IN A lc-host-blizzard"
+        local-data: "edge.blizzard.top.comcast.net. 30 IN A lc-host-blizzard"
         local-zone: "edgecast.blizzard.com." redirect
-        local-data: "edgecast.blizzard.com. 600 IN A lc-host-blizzard"
+        local-data: "edgecast.blizzard.com. 30 IN A lc-host-blizzard"
         local-zone: "nydus.battle.net." redirect
-        local-data: "nydus.battle.net. 600 IN A lc-host-blizzard"
+        local-data: "nydus.battle.net. 30 IN A lc-host-blizzard"
 
         
     ## Hirez °|-lc-host-vint:4
         local-zone: "hirez.http.internapcdn.net." redirect
-        local-data: "hirez.http.internapcdn.net. 600 IN A lc-host-hirez"
+        local-data: "hirez.http.internapcdn.net. 30 IN A lc-host-hirez"
  
     ## Origin °|-lc-host-vint:5
         local-zone: "ea.com." transparent
         local-zone: "akamai.cdn.ea.com." redirect
-        local-data: "akamai.cdn.ea.com. 600 IN A lc-host-origin"
+        local-data: "akamai.cdn.ea.com. 30 IN A lc-host-origin"
         local-zone: "download.origin.com." redirect
-        local-data: "download.origin.com. 600 IN A lc-host-origin"
+        local-data: "download.origin.com. 30 IN A lc-host-origin"
         local-zone: "origin-a.akamaihd.net." redirect
-        local-data: "origin-a.akamaihd.net. 600 IN A lc-host-origin"
+        local-data: "origin-a.akamaihd.net. 30 IN A lc-host-origin"
         local-zone: "lvlt.cdn.ea.com." redirect
-        local-data: "lvlt.cdn.ea.com. 600 IN A lc-host-origin"
+        local-data: "lvlt.cdn.ea.com. 30 IN A lc-host-origin"
         local-zone: "origin-b.akamaihd.net." redirect
-        local-data: "origin-b.akamaihd.net. 600 IN A lc-host-origin"
+        local-data: "origin-b.akamaihd.net. 30 IN A lc-host-origin"
         local-zone: "river.data.ea.com." redirect
-        local-data: "river.data.ea.com. 600 IN A lc-host-origin"
+        local-data: "river.data.ea.com. 30 IN A lc-host-origin"
  
      ## Sony °|-lc-host-vint:6
         local-zone: "pls.patch.station.sony.com." redirect
-        local-data: "pls.patch.station.sony.com. 600 IN A lc-host-sony"
+        local-data: "pls.patch.station.sony.com. 30 IN A lc-host-sony"
         local-zone: "playstation.net." transparent
         local-zone: "gs2.ww.prod.dl.playstation.net." redirect
-        local-data: "gs2.ww.prod.dl.playstation.net. 600 IN A lc-host-sony"
+        local-data: "gs2.ww.prod.dl.playstation.net. 30 IN A lc-host-sony"
         local-zone: "gs2.sonycoment.loris-e.llnwd.net." redirect
-        local-data: "gs2.sonycoment.loris-e.llnwd.net. 600 IN A lc-host-sony"
+        local-data: "gs2.sonycoment.loris-e.llnwd.net. 30 IN A lc-host-sony"
         
           ## Microsoft Windows Updates °|-lc-host-vint:7
         ##### New Added 3/1/2018
         local-zone: "download.microsoft.com." redirect
-        local-data: "download.microsoft.com. 600 IN A lc-host-microsoft"
+        local-data: "download.microsoft.com. 30 IN A lc-host-microsoft"
         local-zone: "update.microsoft.com.akadns.net." redirect
-        local-data: "update.microsoft.com.akadns.net. 600 IN A lc-host-microsoft"
+        local-data: "update.microsoft.com.akadns.net. 30 IN A lc-host-microsoft"
         local-zone: "update.microsoft.com.nsatc.net." redirect
-        local-data: "update.microsoft.com.nsatc.net. 600 IN A lc-host-microsoft"
+        local-data: "update.microsoft.com.nsatc.net. 30 IN A lc-host-microsoft"
         local-zone: "windowsupdate.com." redirect
-        local-data: "windowsupdate.com. 600 IN A lc-host-microsoft"
+        local-data: "windowsupdate.com. 30 IN A lc-host-microsoft"
 	    local-zone: "update.microsoft.com." redirect
-        local-data: "update.microsoft.com. 600 IN A lc-host-microsoft"
+        local-data: "update.microsoft.com. 30 IN A lc-host-microsoft"
         local-zone: "windowsupdate.microsoft.com." redirect
-        local-data: "windowsupdate.microsoft.com. 600 IN A lc-host-microsoft"
+        local-data: "windowsupdate.microsoft.com. 30 IN A lc-host-microsoft"
 	    local-zone: "msxbassets.loris.llnwd.net." redirect
-        local-data: "msxbassets.loris.llnwd.net. 600 IN A lc-host-microsoft"
+        local-data: "msxbassets.loris.llnwd.net. 30 IN A lc-host-microsoft"
         local-zone: "hwcdn.net." redirect
-        local-data: "hwcdn.net. 600 IN A lc-host-microsoft"
+        local-data: "hwcdn.net. 30 IN A lc-host-microsoft"
         local-zone: "assets1.xboxlive.com." redirect
-        local-data: "assets1.xboxlive.com. 600 IN A lc-host-microsoft"
+        local-data: "assets1.xboxlive.com. 30 IN A lc-host-microsoft"
         local-zone: "assets2.xboxlive.com." redirect
-        local-data: "assets2.xboxlive.com. 600 IN A lc-host-microsoft"
+        local-data: "assets2.xboxlive.com. 30 IN A lc-host-microsoft"
         local-zone: "xboxone.loris.llnwd.net." redirect
-        local-data: "xboxone.loris.llnwd.net. 600 IN A lc-host-microsoft"
+        local-data: "xboxone.loris.llnwd.net. 30 IN A lc-host-microsoft"
         local-zone: "xboxone.vo.llnwd.net." redirect
-        local-data: "xboxone.vo.llnwd.net. 600 IN A lc-host-microsoft"
+        local-data: "xboxone.vo.llnwd.net. 30 IN A lc-host-microsoft"
         local-zone: "images-eds.xboxlive.com." redirect
-        local-data: "images-eds.xboxlive.com. 600 IN A lc-host-microsoft"
+        local-data: "images-eds.xboxlive.com. 30 IN A lc-host-microsoft"
         local-zone: "xbox-mbr.xboxlive.com." redirect
-        local-data: "xbox-mbr.xboxlive.com. 600 IN A lc-host-microsoft"
+        local-data: "xbox-mbr.xboxlive.com. 30 IN A lc-host-microsoft"
         local-zone: "assets1.xboxlive.com.nsatc.net." redirect
-        local-data: "assets1.xboxlive.com.nsatc.net. 600 IN A lc-host-microsoft"
+        local-data: "assets1.xboxlive.com.nsatc.net. 30 IN A lc-host-microsoft"
         local-zone: "fullproduct.download.microsoft.com." redirect
-        local-data: "fullproduct.download.microsoft.com. 600 IN A lc-host-microsoft"        
+        local-data: "fullproduct.download.microsoft.com. 30 IN A lc-host-microsoft"        
         local-zone: "dlassets.xboxlive.com." redirect
-        local-data: "dlassets.xboxlive.com. 600 IN A lc-host-microsoft"
+        local-data: "dlassets.xboxlive.com. 30 IN A lc-host-microsoft"
         local-zone: "tlu.dl.delivery.mp.microsoft.com." redirect
-	local-data: "tlu.dl.delivery.mp.microsoft.com. 600 IN A lc-host-microsoft"
+	local-data: "tlu.dl.delivery.mp.microsoft.com. 30 IN A lc-host-microsoft"
         local-zone: "officecdn.microsoft.com.edgesuite.net." redirect
-        local-data: "officecdn.microsoft.com.edgesuite.net. 600 IN A lc-host-microsoft"
+        local-data: "officecdn.microsoft.com.edgesuite.net. 30 IN A lc-host-microsoft"
         #London MS CDNs New 3/17/2018
         local-zone: "lcy.llnw.net." redirect
-        local-data: "lcy.llnw.net. 600 IN A lc-host-microsoft"
+        local-data: "lcy.llnw.net. 30 IN A lc-host-microsoft"
         local-zone: "lon.llnw.net." redirect
-        local-data: "lon.llnw.net. 600 IN A lc-host-microsoft"
+        local-data: "lon.llnw.net. 30 IN A lc-host-microsoft"
 	#XBOX 360 Downloads#
 	local-zone: "download.xbox.com." redirect
-        local-data: "download.xbox.com. 600 IN A lc-host-microsoft"
+        local-data: "download.xbox.com. 30 IN A lc-host-microsoft"
 	    
     ## Tera °|-lc-host-vint:8
         local-zone: "patch.tera.enmasse-game.com." redirect
-        local-data: "patch.tera.enmasse-game.com. 600 IN A lc-host-enmasse"
+        local-data: "patch.tera.enmasse-game.com. 30 IN A lc-host-enmasse"
         local-zone: "patch.closers.enmasse-game.com." redirect
-        local-data: "patch.closers.enmasse-game.com. 600 IN A lc-host-enmasse"
+        local-data: "patch.closers.enmasse-game.com. 30 IN A lc-host-enmasse"
         local-zone: "download.enmasse.com." redirect
-        local-data: "download.enmasse.com. 600 IN A lc-host-enmasse"
+        local-data: "download.enmasse.com. 30 IN A lc-host-enmasse"
 
     ## GOG °|-lc-host-vint:9
         local-zone: "cdn.gog.com." redirect
-        local-data: "cdn.gog.com. 600 IN A lc-host-gog"
+        local-data: "cdn.gog.com. 30 IN A lc-host-gog"
         local-zone: "wpc.11df.deltacdn.net." redirect
-        local-data: "wpc.11df.deltacdn.net. 600 IN A lc-host-gog"
+        local-data: "wpc.11df.deltacdn.net. 30 IN A lc-host-gog"
         local-zone: "11df-eu-lb.wpc.edgecastcdn.net." redirect
-        local-data: "11df-eu-lb.wpc.edgecastcdn.net. 600 IN A lc-host-gog"
+        local-data: "11df-eu-lb.wpc.edgecastcdn.net. 30 IN A lc-host-gog"
         local-zone: "11df-eu-lb.apr-11df.edgecastdns.net." redirect
-        local-data: "11df-eu-lb.apr-11df.edgecastdns.net. 600 IN A lc-host-gog"
+        local-data: "11df-eu-lb.apr-11df.edgecastdns.net. 30 IN A lc-host-gog"
         
     ## Arena networks °|-lc-host-vint:10
         local-zone: "arenanetworks.com." transparent
-        local-data: "assetcdn.101.arenanetworks.com. 600 IN A lc-host-arena"
-        local-data: "assetcdn.102.arenanetworks.com. 600 IN A lc-host-arena"
-        local-data: "assetcdn.103.arenanetworks.com. 600 IN A lc-host-arena"
-        local-data: "live.patcher.bladeandsoul.com. 600 IN A lc-host-arena"
+        local-data: "assetcdn.101.arenanetworks.com. 30 IN A lc-host-arena"
+        local-data: "assetcdn.102.arenanetworks.com. 30 IN A lc-host-arena"
+        local-data: "assetcdn.103.arenanetworks.com. 30 IN A lc-host-arena"
+        local-data: "live.patcher.bladeandsoul.com. 30 IN A lc-host-arena"
 
 ## Wargaming °|-lc-host-vint:11
         local-zone: "wargaming.net." transparent
         local-zone: "wg.gcdn.co." redirect
-        local-data: "wg.gcdn.co. 600 IN A lc-host-wargaming"
+        local-data: "wg.gcdn.co. 30 IN A lc-host-wargaming"
         local-zone: "wargaming.net.edgesuite.net." redirect
-        local-data: "wargaming.net.edgesuite.net. 600 IN A lc-host-wargaming"
+        local-data: "wargaming.net.edgesuite.net. 30 IN A lc-host-wargaming"
         local-zone: "wgusst-na.wargaming.net." redirect
-        local-data: "wgusst-na.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "wgusst-na.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "wgusst-eu.wargaming.net." redirect
-        local-data: "wgusst-eu.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "wgusst-eu.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "update-v4r4h10x.worldofwarships.com." redirect
-        local-data: "update-v4r4h10x.worldofwarships.com. 600 IN A lc-host-wargaming"
+        local-data: "update-v4r4h10x.worldofwarships.com. 30 IN A lc-host-wargaming"
         local-zone: "static-sguscs.worldofwarships.com." redirect
-        local-data: "static-sguscs.worldofwarships.com. 600 IN A lc-host-wargaming"
+        local-data: "static-sguscs.worldofwarships.com. 30 IN A lc-host-wargaming"
         local-zone: "dl2.wargaming.net." redirect
-        local-data: "dl2.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "dl2.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "dl-wows-ak.wargaming.net." redirect
-        local-data: "dl-wows-ak.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "dl-wows-ak.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "dl-wows-cdx.wargaming.net." redirect
-        local-data: "dl-wows-cdx.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "dl-wows-cdx.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "dl-wows-gc.wargaming.net." redirect
-        local-data: "dl-wows-gc.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "dl-wows-gc.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "dl-wot-cdx.wargaming.net." redirect
-        local-data: "dl-wot-cdx.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "dl-wot-cdx.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "dl-wot-gc.wargaming.net." redirect
-        local-data: "dl-wot-gc.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "dl-wot-gc.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "dl-wowp-cdx.wargaming.net." redirect
-        local-data: "dl-wowp-cdx.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "dl-wowp-cdx.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "dl-wowp-gc.wargaming.net." redirect
-        local-data: "dl-wowp-gc.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "dl-wowp-gc.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "wguswgc-na.wargaming.net." redirect
-        local-data: "wguswgc-na.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "wguswgc-na.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "wguscs-wotcom.wargaming.net." redirect
-        local-data: "wguscs-wotcom.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "wguscs-wotcom.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "wguscs-twaeu.wargaming.net." redirect
-        local-data: "wguscs-twaeu.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "wguscs-twaeu.wargaming.net. 30 IN A lc-host-wargaming"
         local-zone: "dl-twa-gc.wargaming.net." redirect
-        local-data: "dl-twa-gc.wargaming.net. 600 IN A lc-host-wargaming"
+        local-data: "dl-twa-gc.wargaming.net. 30 IN A lc-host-wargaming"
 
     ## Blackhole Wargaming Torrent hosts
         local-zone: "dht.transmissionbt.com." refuse
@@ -263,36 +263,36 @@ server:
     
     ## Uplay °|-lc-host-vint:12
         local-zone: "cdn.ubi.com." redirect
-        local-data: "cdn.ubi.com. 600 IN A lc-host-uplay"
+        local-data: "cdn.ubi.com. 30 IN A lc-host-uplay"
 
     ## OSX Updates °|-lc-host-vint:13
         local-zone: "mzstatic.com." redirect
-        local-data: "mzstatic.com. 600 IN A lc-host-apple"
+        local-data: "mzstatic.com. 30 IN A lc-host-apple"
         local-zone: "swcdn.apple.com." redirect
-        local-data: "swcdn.apple.com. 600 IN A lc-host-apple"
+        local-data: "swcdn.apple.com. 30 IN A lc-host-apple"
         local-zone: "itunes-apple.com." redirect
-        local-data: "itunes-apple.com. 600 IN A lc-host-apple"
+        local-data: "itunes-apple.com. 30 IN A lc-host-apple"
         local-zone: "swscan.apple.com." redirect
-        local-data: "swscan.apple.com. 600 IN A lc-host-apple"
+        local-data: "swscan.apple.com. 30 IN A lc-host-apple"
         local-zone: "osxapps.itunes.apple.com." redirect
-        local-data: "osxapps.itunes.apple.com. 600 IN A lc-host-apple"
+        local-data: "osxapps.itunes.apple.com. 30 IN A lc-host-apple"
         
     ## Glyph °|-lc-host-vint:14
         local-zone: "aa-update.dyn.triongames.com." redirect
-        local-data: "aa-update.dyn.triongames.com. 600 IN A lc-host-glyph"   
+        local-data: "aa-update.dyn.triongames.com. 30 IN A lc-host-glyph"   
         
     ## ZeniMax °|-lc-host-vint:15
         local-zone: "patcher.elderscrollsonline.com." redirect
-        local-data: "patcher.elderscrollsonline.com. 600 IN A lc-host-zenimax"
+        local-data: "patcher.elderscrollsonline.com. 30 IN A lc-host-zenimax"
 
 
      ## digitalextremes °|-lc-host-vint:16
         local-zone: "content.warframe.com." redirect
-        local-data: "content.warframe.com. 600 IN A lc-host-digitalextremes"
+        local-data: "content.warframe.com. 30 IN A lc-host-digitalextremes"
         
      ## pearlabyss °|-lc-host-vint:17
         local-zone: "akamai-gamecdn.blackdesertonline.com." redirect
-        local-data: "akamai-gamecdn.blackdesertonline.com. 600 IN A lc-host-pearlabyss"
+        local-data: "akamai-gamecdn.blackdesertonline.com. 30 IN A lc-host-pearlabyss"
 
 
 

--- a/install-lancache.sh
+++ b/install-lancache.sh
@@ -30,7 +30,13 @@ TIMESTAMP=$(date +%s)
 
 # Update packages
 echo "Installing package updates..."
-apt -y update
+universeCheck=$(apt-cache policy |grep universe)
+if [[ -z $universe ]]; then
+	echo "Adding universe repository..."
+	apt-add-repository universe
+else
+	apt -y update
+fi
 apt -y upgrade
 
 # Install required packages


### PR DESCRIPTION
1) The Ubuntu universe repository is necessary to install sniproxy, and unbound, and netdata which is not included by default in the new live-server iso.
2) Having a ttl of 10 minutes is too long, backed down to 30 seconds. Then if an IP change needs to occur during an event, clients will request the new IP after 30 seconds instead of 10 minutes.