### PR TITLE
User changeable max_size, bug fixes, and changed nginx errors folder

### DIFF
--- a/etc/nginx/lancache/caches
+++ b/etc/nginx/lancache/caches
@@ -1,29 +1,29 @@
-proxy_cache_path lc-srv-loc/data/installs levels=2:2 keys_zone=installs:500m inactive=120d max_size=972800m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/other levels=2:2 keys_zone=other:100m inactive=72h max_size=10240m;
+proxy_cache_path lc-srv-loc/data/installs levels=2:2 keys_zone=installs:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/other levels=2:2 keys_zone=other:100m inactive=72h max_size=lc-max-size;
 
 proxy_temp_path lc-srv-loc/data/tmp/ 1 2;
 
-proxy_cache_path lc-srv-loc/data/blizzard levels=2:2 keys_zone=blizzard:500m inactive=120d max_size=100000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/steam levels=2:2 keys_zone=steam:500m inactive=120d max_size=5000000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/origin levels=2:2 keys_zone=origin:500m inactive=120d max_size=100000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/blizzard levels=2:2 keys_zone=blizzard:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/steam levels=2:2 keys_zone=steam:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/origin levels=2:2 keys_zone=origin:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
 
-proxy_cache_path lc-srv-loc/data/hirez levels=2:2 keys_zone=hirez:500m inactive=120d max_size=75000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/riot levels=2:2 keys_zone=riot:500m inactive=120d max_size=75000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/sony levels=2:2 keys_zone=sony:500m inactive=120d max_size=50000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/hirez levels=2:2 keys_zone=hirez:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/riot levels=2:2 keys_zone=riot:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/sony levels=2:2 keys_zone=sony:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
 
 #Added by Nexusofdoom
-proxy_cache_path lc-srv-loc/data/enmasse levels=2:2 keys_zone=enmasse:500m inactive=120d max_size=50000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/microsoft levels=2:2 keys_zone=microsoft:500m inactive=120d max_size=50000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/wargaming levels=2:2 keys_zone=wargaming:500m inactive=120d max_size=50000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/arenanetworks levels=2:2 keys_zone=arenanetworks:500m inactive=120d max_size=50000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/apple levels=2:2 keys_zone=apple:500m inactive=888d max_size=500000m loader_files=4000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/glyph levels=2:2 keys_zone=glyph:500m inactive=888d max_size=500000m loader_files=4000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/zenimax levels=2:2 keys_zone=zenimax:500m inactive=888d max_size=500000m loader_files=4000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/digitalextremes levels=2:2 keys_zone=digitalextremes:500m inactive=888d max_size=500000m loader_files=4000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path lc-srv-loc/data/pearlabyss levels=2:2 keys_zone=pearlabyss:500m inactive=888d max_size=500000m loader_files=4000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/enmasse levels=2:2 keys_zone=enmasse:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/microsoft levels=2:2 keys_zone=microsoft:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/wargaming levels=2:2 keys_zone=wargaming:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/arenanetworks levels=2:2 keys_zone=arenanetworks:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/apple levels=2:2 keys_zone=apple:500m inactive=888d max_size=lc-max-size loader_files=4000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/glyph levels=2:2 keys_zone=glyph:500m inactive=888d max_size=lc-max-size loader_files=4000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/zenimax levels=2:2 keys_zone=zenimax:500m inactive=888d max_size=lc-max-size loader_files=4000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/digitalextremes levels=2:2 keys_zone=digitalextremes:500m inactive=888d max_size=lc-max-size loader_files=4000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/pearlabyss levels=2:2 keys_zone=pearlabyss:500m inactive=888d max_size=lc-max-size loader_files=4000 loader_sleep=50ms loader_threshold=300ms;
 
 #Based of ForayJones Lancache
-proxy_cache_path lc-srv-loc/data/gog levels=2:2 keys_zone=gog:500m inactive=120d max_size=50000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/gog levels=2:2 keys_zone=gog:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
 
 #Based of Steamcache CDN Uplay
-proxy_cache_path lc-srv-loc/data/uplay levels=2:2 keys_zone=uplay:500m inactive=120d max_size=50000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path lc-srv-loc/data/uplay levels=2:2 keys_zone=uplay:500m inactive=120d max_size=lc-max-size loader_files=1000 loader_sleep=50ms loader_threshold=300ms;

--- a/etc/nginx/sites-available/lancache-apple.conf
+++ b/etc/nginx/sites-available/lancache-apple.conf
@@ -3,7 +3,7 @@ server {
     server_name osx _;
     access_log lc-srv-loc/logs/access/apple.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/apple.log keys_slice buffer=128k flush=1m;
-    error_log lc-srv-loc/logs/error/apple.log;
+    error_log lc-srv-loc/logs/errors/apple.log;
 
     # Apple Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-arenanetworks.conf
+++ b/etc/nginx/sites-available/lancache-arenanetworks.conf
@@ -4,7 +4,7 @@ server {
         # DNS entries: lancache-
         access_log lc-srv-loc/logs/access/arenanetworks.log main buffer=128k flush=1m;
         access_log lc-srv-loc/logs/keys/arenanetworks.log keys_default buffer=128k flush=1m;
-        error_log lc-srv-loc/logs/errors/arenanetworks.log;
+        error_log lc-srv-loc/logs/error/arenanetworks.log;
 
     # Default Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-arenanetworks.conf
+++ b/etc/nginx/sites-available/lancache-arenanetworks.conf
@@ -4,7 +4,7 @@ server {
         # DNS entries: lancache-
         access_log lc-srv-loc/logs/access/arenanetworks.log main buffer=128k flush=1m;
         access_log lc-srv-loc/logs/keys/arenanetworks.log keys_default buffer=128k flush=1m;
-        error_log lc-srv-loc/logs/error/arenanetworks.log;
+        error_log lc-srv-loc/logs/errors/arenanetworks.log;
 
     # Default Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-blizzard.conf
+++ b/etc/nginx/sites-available/lancache-blizzard.conf
@@ -3,7 +3,7 @@ server {
 	server_name blizzard _;
 	access_log lc-srv-loc/logs/access/blizzard.log main buffer=128k flush=1m;
 	access_log lc-srv-loc/logs/keys/blizzard.log keys_range buffer=128k flush=1m;
-	error_log lc-srv-loc/logs/error/blizzard.log;
+	error_log lc-srv-loc/logs/errors/blizzard.log;
 
 	# Blizzard Node
 	include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-digitalextremes.conf
+++ b/etc/nginx/sites-available/lancache-digitalextremes.conf
@@ -3,7 +3,7 @@ server {
         server_name digitalextremes _;
         access_log lc-srv-loc/logs/access/digitalextremes.log main buffer=128k flush=1m;
         access_log lc-srv-loc/logs/keys/digitalextremes.log keys_range buffer=128k flush=1m;
-        error_log lc-srv-loc/logs/error/digitalextremes.log;
+        error_log lc-srv-loc/logs/errors/digitalextremes.log;
 
         # Digitalextremes -Warframe- Node
         include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-enmasse.conf
+++ b/etc/nginx/sites-available/lancache-enmasse.conf
@@ -3,7 +3,7 @@ server {
     server_name enmasse _;
     access_log lc-srv-loc/logs/access/enmasse.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/enmasse.log keys_slice buffer=128k flush=1m;
-    error_log lc-srv-loc/logs/error/enmasse.log;
+    error_log lc-srv-loc/logs/errors/enmasse.log;
 
     # Enmasse Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-glyph.conf
+++ b/etc/nginx/sites-available/lancache-glyph.conf
@@ -3,7 +3,7 @@ server {
     server_name glyph _;
     access_log lc-srv-loc/logs/access/glyph.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/glyph.log keys_range buffer=128k flush=1m;
-    error_log lc-srv-loc/logs/error/glyph.log;
+    error_log lc-srv-loc/logs/errors/glyph.log;
 
     # Default Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-gog.conf
+++ b/etc/nginx/sites-available/lancache-gog.conf
@@ -3,7 +3,7 @@ server {
 	server_name gog _;
     access_log lc-srv-loc/logs/access/gog.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/gog.log keys_range buffer=128k flush=1m;
-    error_log lc-srv-loc/logs/error/gog.log;
+    error_log lc-srv-loc/logs/errors/gog.log;
 
 	# Default Node
 	include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-hirez.conf
+++ b/etc/nginx/sites-available/lancache-hirez.conf
@@ -6,7 +6,7 @@ server {
 	# more than just hirez e.g. store.steampowered.com which is https.
 	access_log lc-srv-loc/logs/access/hirez.log main buffer=128k flush=1m;
 	access_log lc-srv-loc/logs/keys/hirez.log keys_range buffer=128k flush=1m;
-	error_log lc-srv-loc/logs/error/hirez.log;
+	error_log lc-srv-loc/logs/errors/hirez.log;
 	
 	# Default Node
 	include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-microsoft.conf
+++ b/etc/nginx/sites-available/lancache-microsoft.conf
@@ -4,7 +4,7 @@ server {
         server_name microsoft _;
         access_log lc-srv-loc/logs/access/microsoft.log main buffer=128k flush=1m;
         access_log lc-srv-loc/logs/keys/microsoft.log keys_slice buffer=128k flush=1m;
-        error_log lc-srv-loc/logs/error/microsoft.log;
+        error_log lc-srv-loc/logs/errors/microsoft.log;
 
         # microsoft Node
         include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-origin.conf
+++ b/etc/nginx/sites-available/lancache-origin.conf
@@ -3,7 +3,7 @@ server {
     server_name origin _;
     access_log lc-srv-loc/logs/access/origin.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/origin.log keys_slice buffer=128k flush=1m;
-    error_log lc-srv-loc/logs/error/origin.log;
+    error_log lc-srv-loc/logs/errors/origin.log;
     
     proxy_cache_background_update on;
 

--- a/etc/nginx/sites-available/lancache-pearlabyss.conf
+++ b/etc/nginx/sites-available/lancache-pearlabyss.conf
@@ -3,7 +3,7 @@ server {
     server_name pearlabyss _;
     access_log lc-srv-loc/logs/access/pearlabyss.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/pearlabyss.log keys_uri buffer=128k flush=1m;
-    error_log lc-srv-loc/logs/error/pearlabyss.log;
+    error_log lc-srv-loc/logs/errors/pearlabyss.log;
 
     # Default Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-riot.conf
+++ b/etc/nginx/sites-available/lancache-riot.conf
@@ -4,7 +4,7 @@ server {
     server_name riot _;
     access_log lc-srv-loc/logs/access/riot.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/riot.log keys_range buffer=128k flush=1m;
-    error_log lc-srv-loc/logs/error/riot.log;
+    error_log lc-srv-loc/logs/errors/riot.log;
 
     # Default Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-sony.conf
+++ b/etc/nginx/sites-available/lancache-sony.conf
@@ -3,7 +3,7 @@ server {
     server_name sony _;
     access_log lc-srv-loc/logs/access/sony.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/sony.log keys_range buffer=128k flush=1m;
-    error_log lc-srv-loc/logs/error/sony.log;
+    error_log lc-srv-loc/logs/errors/sony.log;
 
     # Default Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-steam.conf
+++ b/etc/nginx/sites-available/lancache-steam.conf
@@ -3,7 +3,7 @@ server {
     server_name steam _;
     access_log lc-srv-loc/logs/access/steam.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/steam.log keys_uri;
-    error_log lc-srv-loc/logs/error/steam.log;
+    error_log lc-srv-loc/logs/errors/steam.log;
 
     # Steam Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-uplay.conf
+++ b/etc/nginx/sites-available/lancache-uplay.conf
@@ -4,7 +4,7 @@ server {
     server_name ubi _;
     access_log lc-srv-loc/logs/access/uplay.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/uplay.log keys_range buffer=128k flush=1m;
-    error_log lc-srv-loc/logs/error/uplay.log;
+    error_log lc-srv-loc/logs/errors/uplay.log;
 
     # Default Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-wargaming.conf
+++ b/etc/nginx/sites-available/lancache-wargaming.conf
@@ -3,7 +3,7 @@ server {
     server_name wargaming _;
     access_log lc-srv-loc/logs/access/wargaming.log main buffer=128k flush=1m;
     access_log lc-srv-loc/logs/keys/wargaming.log keys_range buffer=128k flush=1m;
-    error_log lc-srv-loc/logs/error/wargaming.log;
+    error_log lc-srv-loc/logs/errors/wargaming.log;
 
     # Default Node
     include lancache/resolver;

--- a/etc/nginx/sites-available/lancache-zenimax.conf
+++ b/etc/nginx/sites-available/lancache-zenimax.conf
@@ -3,7 +3,7 @@ server {
         server_name zenimax _;
         access_log lc-srv-loc/logs/access/zenimax.log main buffer=128k flush=1m;
         access_log lc-srv-loc/logs/keys/zenimax.log keys_range buffer=128k flush=1m;
-        error_log lc-srv-loc/logs/error/zenimax.log;
+        error_log lc-srv-loc/logs/errors/zenimax.log;
 
         # Zenimax -ESO- Node
         include lancache/resolver;

--- a/install-lancache.sh
+++ b/install-lancache.sh
@@ -5,11 +5,15 @@ if [[ "$EUID" -ne 0 ]]; then
 	exit 1
 fi
 
-# Changeable variables
-# Leaving defaults is fine
+# Changeable variables, leaving the defaults is fine
+# File path for lancache
 lc_srv_loc="/srv/lancache"
+# Primary DNS Server
 lc_dns1="8.8.8.8"
+# Secondary DNS Server
 lc_dns2="4.2.2.2"
+# Proxy cache size, measued in Megabytes (MB). Default is 500GB
+lc_max_size="500000m"
 
 # Variables you should most likely not touch
 # Unless you know what you are doing
@@ -31,7 +35,7 @@ TIMESTAMP=$(date +%s)
 # Update packages
 echo "Installing package updates..."
 universeCheck=$(apt-cache policy |grep universe)
-if [[ -z $universe ]]; then
+if [[ -z $universeCheck ]]; then
 	echo "Adding universe repository..."
 	apt-add-repository universe
 else
@@ -166,6 +170,10 @@ chown -R www-data:www-data $lc_srv_loc
 echo "Configuring lancache directory structure in nginx..."
 sed -i "s|lc-srv-loc|$lc_srv_loc|g" $lc_base_folder/etc/nginx/sites-available/*.conf
 sed -i "s|lc-srv-loc|$lc_srv_loc|g" $lc_base_folder/etc/nginx/lancache/caches
+
+# Setting the max_size limit for eache cache
+echo "Configuring proxy cache size..."
+sed -i "s|lc-max-size|$lc_max_size|g" $lc_base_folder/etc/nginx/lancache/caches
 
 # Setting specified DNS Servers
 echo "Setting specified DNS Servers..."

--- a/install-lancache.sh
+++ b/install-lancache.sh
@@ -53,7 +53,7 @@ declare -a lc_services=(arena apple blizzard hirez gog glyph microsoft origin ri
 # Installer Folders
 declare -a lc_folders=(config data logs temp)
 # Log Folders
-declare -a lc_logfolders=(access error keys)
+declare -a lc_logfolders=(access errors keys)
 
 declare -a ip_eth=$(ip link show | grep ens | tr ":" " " | awk '{ print $2 }')
 for int in ${ip_eth[@]}; do


### PR DESCRIPTION
1. Users can now specify the max_size for their proxy cache
2. Nginx errors folder for caches was "error" which is resulting in bugs as people assume it's "errors." Changed to "errors"
3. Misc bug fixes